### PR TITLE
YouTube実行時にトークンと動画URLをAPI側にポストするように変更

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -63,8 +63,9 @@ async def on_message(message):
         logger.debug(f"url -> {url}")
         # await message.channel.send(start_youtube_download(url))
         common_phrase = os.environ["COMMON_PHRASE"]
-        payload = {'key1': common_phrase, 'key2': url}
-        r = requests.post(os.environ["POST_TARGET"], data=payload)
-        r.status_code # debug
+        header = {"Authorization": f"Bearer {common_phrase}"}
+        payload = {'videoURL': url}
+        r = requests.post(os.environ["POST_TARGET"], headers=header, json=payload)
+        # r.status_code # debug
 
 client.run(os.environ["MUSIC_TOKEN"])

--- a/bot/main.py
+++ b/bot/main.py
@@ -57,10 +57,14 @@ async def on_message(message):
                 "?help: return command list.\n"
                 "```"
             )
-    
+
     if message.content.startswith("?yd_https://www.youtube"):
         url = message.content[4:]
         logger.debug(f"url -> {url}")
-        await message.channel.send(start_youtube_download(url))
+        # await message.channel.send(start_youtube_download(url))
+        common_phrase = os.environ["COMMON_PHRASE"]
+        payload = {'key1': common_phrase, 'key2': url}
+        r = requests.post(os.environ["POST_TARGET"], data=payload)
+        r.status_code # debug
 
 client.run(os.environ["MUSIC_TOKEN"])


### PR DESCRIPTION
- 元のダウンロード処理をコメントアウト
- トークン、ポスト先URLをenvファイルから取得
- トークンと動画URLをポストする処理を追加
- POSTにはRFC6750 Bearer認証を採用